### PR TITLE
fix: thisQuarter 季度格式化修复 + 公开项目文档规范（v0.0.55）

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import { deepCopy, Typeof, getDateRange, downloadFile } from "hsu-utils";
 
 const copy = deepCopy({ a: [1, 2, 3] });
 Typeof([], "array"); // true
-getDateRange({ type: "thisWeek" }); // ['2026-07-13', '2026-07-19']
+getDateRange({ type: "thisWeek", baseDate: "2026-07-17" }); // ['2026-07-12', '2026-07-18']（以周日为一周起点）
 await downloadFile("https://example.com/report.xlsx", "报表.xlsx");
 ```
 
@@ -130,7 +130,7 @@ await downloadFile("https://example.com/report.xlsx", "报表.xlsx");
 - `past` - 过去
 - `future` - 未来
 - `today` - 当日
-- `thisWeek` - 当周
+- `thisWeek` - 当周（以**周日**为一周起点）
 - `thisMonth` - 当月
 - `thisQuarter` - 当季
 - `thisYear` - 当年

--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
-# [Hsu Utils](https://github.com/VitaTsui/hsu-utils#hsu-utils)
+# hsu-utils
 
-## 前言
+[![npm version](https://img.shields.io/npm/v/hsu-utils.svg)](https://www.npmjs.com/package/hsu-utils)
+[![license](https://img.shields.io/npm/l/hsu-utils.svg)](./LICENSE)
 
-`hsu-utils` 一些前端的工具集
+常用前端工具集：深拷贝、类型判断、相等比较、文件下载、PDF 渲染、日期范围、控制台表格、字符串尺寸测量等，TypeScript 编写，零业务依赖。
 
 ## 安装
 
-```sh
-npm install --save hsu-utils
+```bash
+npm install hsu-utils
 # 或
 yarn add hsu-utils
 ```
 
-## 功能
+## 使用
+
+```ts
+import { deepCopy, Typeof, getDateRange, downloadFile } from "hsu-utils";
+
+const copy = deepCopy({ a: [1, 2, 3] });
+Typeof([], "array"); // true
+getDateRange({ type: "thisWeek" }); // ['2026-07-13', '2026-07-19']
+await downloadFile("https://example.com/report.xlsx", "报表.xlsx");
+```
+
+## API 一览
 
 | 方法              | 子方法                | 说明                            | 类型                                                                                          | 备注                             |
 | ----------------- | --------------------- | ------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------- |
@@ -77,9 +89,9 @@ yarn add hsu-utils
 | 参数         | 说明         | 类型   | 默认值 | 备注 |
 | ------------ | ------------ | ------ | ------ | ---- |
 | pdfUrl       | pdf 文件地址 | string | -      | 必填 |
-| containerId  | pdf 容器 id  | string | normal | 必填 |
-| startPageNum | 开始页码     | number | normal | -    |
-| endPageNum   | 结束页码     | number | normal | -    |
+| containerId  | pdf 容器 id  | string | -      | 必填 |
+| startPageNum | 开始页码     | number | -      | -    |
+| endPageNum   | 结束页码     | number | -      | -    |
 | pixelRatio   | 像素比例     | number | 2      | -    |
 | scale        | 缩放         | number | 1      | -    |
 
@@ -137,6 +149,18 @@ yarn add hsu-utils
 
 注意：当 `hasTime` 为 `true` 时，包含日期部分的格式会自动添加时间部分 `HH:mm:ss`。默认 `hasTime` 为 `false`。时、分、秒单位固定返回 `YYYY-MM-DD HH:mm:ss` 格式。
 
+## 开发
+
+```bash
+yarn          # 安装依赖
+yarn build    # 构建 es/ + lib/ + dist/
+yarn test     # 运行单元测试
+```
+
+## 贡献
+
+日常开发在 `develop` 分支进行（feature 分支合入 `develop`），`main` 只接受来自 `develop` 的 PR；合入 `main` 后按 `package.json` 版本自动打 tag 并发布 npm。PR 标题遵循 [Conventional Commits](https://www.conventionalcommits.org/)。
+
 ## License
 
-MIT
+[MIT](./LICENSE) © VitaHsu

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsu-utils",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "some front-end utils",
   "repository": "git@github.com:VitaTsui/hsu-utils.git",
   "author": "VitaHsu <vitahsu7@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsu-utils",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "some front-end utils",
   "repository": "git@github.com:VitaTsui/hsu-utils.git",
   "author": "VitaHsu <vitahsu7@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsu-utils",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "常用前端工具集：深拷贝、类型判断、相等比较、文件下载、PDF 渲染、日期范围、控制台表格等",
   "keywords": [
     "utils",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,21 @@
 {
   "name": "hsu-utils",
   "version": "0.0.54",
-  "description": "some front-end utils",
-  "repository": "git@github.com:VitaTsui/hsu-utils.git",
+  "description": "常用前端工具集：深拷贝、类型判断、相等比较、文件下载、PDF 渲染、日期范围、控制台表格等",
+  "keywords": [
+    "utils",
+    "frontend",
+    "deep-copy",
+    "download",
+    "pdf",
+    "date-range",
+    "typescript"
+  ],
+  "homepage": "https://github.com/VitaTsui/hsu-utils#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VitaTsui/hsu-utils.git"
+  },
   "author": "VitaHsu <vitahsu7@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",

--- a/tools/ArrayIsIncludes/index.ts
+++ b/tools/ArrayIsIncludes/index.ts
@@ -10,6 +10,12 @@ function countMap<T>(arr: Array<T>) {
   return map
 }
 
+/**
+ * Check whether one array contains another (whether the longer array contains all elements of the shorter one, including duplicate counts)
+ * @param arr1 first array
+ * @param arr2 second array
+ * @returns false if either array is empty; otherwise whether the longer array contains the shorter one
+ */
 export default function array_is_includes<T>(arr1: Array<T>, arr2: Array<T>) {
   if (arr1.length === 0 || arr2.length === 0) {
     return false

--- a/tools/ConsoleTable/index.ts
+++ b/tools/ConsoleTable/index.ts
@@ -6,7 +6,7 @@ const HIGH = '|'
 const SPACE = ' '
 const EMPTY = ''
 
-// 获取字符串的占位长度
+// Get the display width of a string
 function get_string_width(str: string): number {
   let width = 0
   for (const char of str) {
@@ -16,7 +16,7 @@ function get_string_width(str: string): number {
   return width
 }
 
-// 边框长度
+// Generate a horizontal border segment of the given width
 function get_egde(width: number) {
   let edge = ''
   for (let i = 0; i <= width; i++) {
@@ -25,7 +25,7 @@ function get_egde(width: number) {
   return edge
 }
 
-// 生成边框
+// Generate a border row
 function get_edge(widths: number[], no_line_break: boolean = false) {
   const col_num = widths.length
   let border = ''
@@ -41,7 +41,7 @@ function get_edge(widths: number[], no_line_break: boolean = false) {
   return border
 }
 
-// 占位
+// Generate whitespace padding of the given width
 function get_space(width: number): string {
   let space = ''
   for (let i = 0; i <= width; i++) {
@@ -50,7 +50,7 @@ function get_space(width: number): string {
   return space
 }
 
-// 写入数据
+// Write a data row
 function wirte_data(widths: number[], data: (string | number)[]): string {
   const col_num = widths.length
   let content = ''
@@ -75,7 +75,7 @@ function wirte_data(widths: number[], data: (string | number)[]): string {
   return content
 }
 
-// 获取数据的最大占位长度
+// Get the maximum display width of each column
 function get_max_widths(data: ConsoleData): number[] {
   let max_widths = Object.keys(data[0]).map((v) => +v)
 
@@ -88,7 +88,11 @@ function get_max_widths(data: ConsoleData): number[] {
   return max_widths
 }
 
-// 打印表格通用方法
+/**
+ * Print a MySQL-client-style table to the console
+ * @param data 2D array; the first row is the header
+ * @param callBack optional callback that receives the assembled table string (for custom output)
+ */
 export default function console_table(data: ConsoleData, callBack?: (str: string) => void) {
   const row_num = data.length
   const max_widths = get_max_widths(data)

--- a/tools/ConvertNumbers/index.ts
+++ b/tools/ConvertNumbers/index.ts
@@ -4,6 +4,13 @@ export interface C_Options {
   benchmark?: number
   textType?: TextType
 }
+/**
+ * Convert a number to Chinese numerals
+ * @param num the number to convert
+ * @param options.benchmark multiplier (num is multiplied by this value before conversion)
+ * @param options.textType output style: 'lowercase' for lowercase numerals (一二三), 'uppercase' for uppercase numerals (壹贰叁); defaults to 'lowercase'
+ * @returns the Chinese numeral string
+ */
 export function toChineseNum(num: number, options: C_Options = {}) {
   const { benchmark, textType = 'lowercase' } = options
 
@@ -11,35 +18,35 @@ export function toChineseNum(num: number, options: C_Options = {}) {
     lowercase: ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九'],
     uppercase: ['零', '壹', '贰', '叁', '肆', '伍', '陆', '柒', '捌', '玖']
   }
-  // 基本单位
+  // Basic units
   const cnIntRadice = {
     lowercase: ['', '十', '百', '千'],
     uppercase: ['', '拾', '佰', '仟']
   }
-  // 对应整数部分扩展单位
+  // Extended units for the integer part
   const cnIntUnits = {
     lowercase: ['', '万', '亿', '兆'],
     uppercase: ['', '萬', '億', '兆']
   }
-  // 最大处理的数字
+  // Maximum number that can be handled
   const maxNum = 9999999999999999.9999999999999999
-  // 整数部分
+  // Integer part
   let integerNum: string | undefined = undefined
-  // 小数部分
+  // Decimal part
   let decimalNum: string | undefined = undefined
-  // 输出的中文字符串
+  // Output Chinese string
   let chineseStr = ''
 
   if (benchmark) {
     num *= benchmark
   }
 
-  // 超出转换范围
+  // Out of conversion range
   if (num > maxNum) {
     return '超出转换范围'
   }
 
-  // 分割整数和小数
+  // Split into integer and decimal parts
   const moneyStr = num.toString()
   integerNum = moneyStr.split('.')[0]
   decimalNum = moneyStr.split('.')[1]

--- a/tools/DeepCopy/index.ts
+++ b/tools/DeepCopy/index.ts
@@ -3,9 +3,9 @@ import { Typeof } from '..'
 type CommonObj<T = unknown> = Record<string, T>
 
 /**
- * 深拷贝
- * @param data
- * @returns
+ * Deep copy (supports plain objects, arrays, Date, FormData, Set, Map and other common types)
+ * @param data the data to copy
+ * @returns a new deep-copied value
  */
 export default function deepCopy<T>(data: T): T {
   if (Typeof(data) === 'date') {
@@ -48,7 +48,7 @@ export default function deepCopy<T>(data: T): T {
   if (Array.isArray(data)) {
     const newData = data.map((item) => {
       if (typeof item === 'object') {
-        return deepCopy(item) // 数组 | 对象
+        return deepCopy(item) // array | object
       } else {
         return item
       }
@@ -56,17 +56,17 @@ export default function deepCopy<T>(data: T): T {
 
     return newData as T
 
-    // 对象
+    // object
   } else if (data && Typeof(data) === 'object') {
     const _data = data as CommonObj
 
-    const newData: CommonObj = {} // 新对象
+    const newData: CommonObj = {} // new object
 
     Object.keys(_data).forEach((key) => {
       const _item = _data[key]
 
       if (typeof _item === 'object') {
-        newData[key] = deepCopy(_item) // 数组 | 对象
+        newData[key] = deepCopy(_item) // array | object
       } else {
         newData[key] = _item
       }

--- a/tools/DownloadFile/index.ts
+++ b/tools/DownloadFile/index.ts
@@ -1,10 +1,41 @@
 import { Typeof } from '..'
 
+/**
+ * 从 Content-Disposition 响应标头中解析文件名
+ */
+export function getFileNameFromHeader(response: Response): string | null {
+  const contentDisposition = response.headers.get('Content-Disposition')
+  if (!contentDisposition) {
+    return null
+  }
+
+  // 尝试匹配 filename*=UTF-8''example.pdf 格式（RFC 5987）
+  const filenameStarMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i)
+  if (filenameStarMatch) {
+    return decodeURIComponent(filenameStarMatch[1])
+  }
+
+  // 尝试匹配 filename="example.pdf" 或 filename=example.pdf 格式
+  const filenameMatch = contentDisposition.match(/filename=["']?([^;"']+)["']?/i)
+  if (filenameMatch) {
+    return decodeURIComponent(filenameMatch[1])
+  }
+
+  return null
+}
+
 async function downloadFileByUrl(url: string, fileName?: string, signal?: AbortSignal): Promise<void> {
   try {
     const response = await fetch(url, { signal })
+
+    // 如果没有传入文件名，尝试从响应标头中获取
+    let finalFileName = fileName
+    if (!finalFileName) {
+      finalFileName = getFileNameFromHeader(response) || undefined
+    }
+
     const arrayBuffer = await response.arrayBuffer()
-    downloadFile(arrayBuffer, fileName)
+    downloadFile(arrayBuffer, finalFileName)
   } catch (error) {
     if ((error as DOMException)?.name !== 'AbortError') {
       const downloadElement = document.createElement('a')

--- a/tools/DownloadFile/index.ts
+++ b/tools/DownloadFile/index.ts
@@ -1,10 +1,27 @@
 import { Typeof } from '..'
 
 /**
- * 从 Content-Disposition 响应标头中解析文件名
+ * 支持的响应类型：Fetch API Response 或 Axios Response
  */
-export function getFileNameFromHeader(response: Response): string | null {
-  const contentDisposition = response.headers.get('Content-Disposition')
+type ResponseLike = Response | { headers: Record<string, string> | { get(name: string): string | null } }
+
+/**
+ * 从 Content-Disposition 响应标头中解析文件名
+ * 支持 Fetch API Response 和 Axios Response
+ */
+export function getFileNameFromHeader(response: ResponseLike): string | null {
+  // 获取 Content-Disposition 标头
+  let contentDisposition: string | null = null
+
+  if (response.headers && typeof response.headers.get === 'function') {
+    // Fetch API Response (headers 是 Headers 对象)
+    contentDisposition = response.headers.get('Content-Disposition')
+  } else if (response.headers && typeof response.headers === 'object') {
+    // Axios Response (headers 是普通对象)
+    const headers = response.headers as Record<string, string>
+    contentDisposition = headers['content-disposition'] || headers['Content-Disposition'] || null
+  }
+
   if (!contentDisposition) {
     return null
   }

--- a/tools/DownloadFile/index.ts
+++ b/tools/DownloadFile/index.ts
@@ -1,23 +1,25 @@
 import { Typeof } from '..'
 
 /**
- * 支持的响应类型：Fetch API Response 或 Axios Response
+ * Supported response types: Fetch API Response or Axios Response
  */
 type ResponseLike = Response | { headers: Record<string, string> | { get(name: string): string | null } }
 
 /**
- * 从 Content-Disposition 响应标头中解析文件名
- * 支持 Fetch API Response 和 Axios Response
+ * Parse the file name from the Content-Disposition response header
+ * Supports Fetch API Response and Axios Response
+ * @param response the response object
+ * @returns the parsed file name, or null if it cannot be parsed
  */
 export function getFileNameFromHeader(response: ResponseLike): string | null {
-  // 获取 Content-Disposition 标头
+  // Get the Content-Disposition header
   let contentDisposition: string | null = null
 
   if (response.headers && typeof response.headers.get === 'function') {
-    // Fetch API Response (headers 是 Headers 对象)
+    // Fetch API Response (headers is a Headers object)
     contentDisposition = response.headers.get('Content-Disposition')
   } else if (response.headers && typeof response.headers === 'object') {
-    // Axios Response (headers 是普通对象)
+    // Axios Response (headers is a plain object)
     const headers = response.headers as Record<string, string>
     contentDisposition = headers['content-disposition'] || headers['Content-Disposition'] || null
   }
@@ -26,13 +28,13 @@ export function getFileNameFromHeader(response: ResponseLike): string | null {
     return null
   }
 
-  // 尝试匹配 filename*=UTF-8''example.pdf 格式（RFC 5987）
+  // Try to match the filename*=UTF-8''example.pdf format (RFC 5987)
   const filenameStarMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i)
   if (filenameStarMatch) {
     return decodeURIComponent(filenameStarMatch[1])
   }
 
-  // 尝试匹配 filename="example.pdf" 或 filename=example.pdf 格式
+  // Try to match the filename="example.pdf" or filename=example.pdf format
   const filenameMatch = contentDisposition.match(/filename=["']?([^;"']+)["']?/i)
   if (filenameMatch) {
     return decodeURIComponent(filenameMatch[1])
@@ -45,7 +47,7 @@ async function downloadFileByUrl(url: string, fileName?: string, signal?: AbortS
   try {
     const response = await fetch(url, { signal })
 
-    // 如果没有传入文件名，尝试从响应标头中获取
+    // If no file name was provided, try to get it from the response header
     let finalFileName = fileName
     if (!finalFileName) {
       finalFileName = getFileNameFromHeader(response) || undefined
@@ -66,6 +68,12 @@ async function downloadFileByUrl(url: string, fileName?: string, signal?: AbortS
   }
 }
 
+/**
+ * Download a file
+ * @param file file content (ArrayBuffer / Blob), or an http(s) URL / local path (string)
+ * @param fileName name to save the file as; when downloading by URL it is inferred from the response header / URL if omitted
+ * @param signal optional AbortSignal to cancel the request when downloading by URL
+ */
 export default async function downloadFile(
   file: ArrayBuffer | Blob | string,
   fileName?: string,

--- a/tools/Equal/index.ts
+++ b/tools/Equal/index.ts
@@ -1,10 +1,10 @@
 import { Typeof, deepCopy } from '..'
 
 /**
- * 判断类型相等
- * @param obj1
- * @param obj2
- * @returns
+ * Check whether two values have the same type
+ * @param obj1 first value
+ * @param obj2 second value
+ * @returns true if the types are the same
  */
 export function TypeEqual<T = unknown>(obj1: T, obj2: T): boolean {
   let isEqual = false
@@ -19,15 +19,15 @@ export function TypeEqual<T = unknown>(obj1: T, obj2: T): boolean {
 }
 
 /**
- * 判断值相等
- * @param obj1
- * @param obj2
- * @returns
+ * Check whether two values are equal (null and undefined are treated as equal; objects / arrays are deep-compared)
+ * @param obj1 first value
+ * @param obj2 second value
+ * @returns true if equal
  */
 export function ValEqual<T = unknown>(obj1: T, obj2: T): boolean {
   let isEqual = false
 
-  // null 与 undefined 在值上相等
+  // null and undefined are equal by value
   if ((obj1 === null && obj2 === undefined) || (obj1 === undefined && obj2 === null)) {
     isEqual = true
   } else {
@@ -44,10 +44,10 @@ export function ValEqual<T = unknown>(obj1: T, obj2: T): boolean {
 }
 
 /**
- * 判断object相等
- * @param obj1
- * @param obj2
- * @returns
+ * Check whether two objects / arrays are equal (deep comparison; arrays are sorted before comparing, so element order is ignored)
+ * @param obj1 first object
+ * @param obj2 second object
+ * @returns true if equal
  */
 export function ObjEqual<T = object>(obj1: T, obj2: T): boolean {
   let isEqual = false

--- a/tools/GenerateRandomStr/index.ts
+++ b/tools/GenerateRandomStr/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Generate a random string of the given length (uppercase and lowercase English letters only)
+ * @param length length of the string
+ * @returns the random string
+ */
 export default function generateRandomStr(length: number): string {
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
   let result = ''

--- a/tools/GetDateRange/__tests__/GetDateRange.test.ts
+++ b/tools/GetDateRange/__tests__/GetDateRange.test.ts
@@ -28,11 +28,19 @@ describe('getDateRange', () => {
   })
 
   test('获取当季范围', () => {
-    const [min, max] = getDateRange({ type: 'thisQuarter' })
-    const today = dayjs()
+    // Assert literal values against a fixed base date, so a broken `Q` token
+    // (e.g. missing advancedFormat plugin rendering "2024-QQ") fails the test
+    const [min, max] = getDateRange({ type: 'thisQuarter', baseDate: '2024-03-20' })
 
-    expect(min).toBe(today.startOf('quarter').format('YYYY-[Q]Q'))
-    expect(max).toBe(today.endOf('quarter').format('YYYY-[Q]Q'))
+    expect(min).toBe('2024-Q1')
+    expect(max).toBe('2024-Q1')
+  })
+
+  test('获取当季范围（跨季度字面值）', () => {
+    const [min, max] = getDateRange({ type: 'thisQuarter', baseDate: '2026-07-17' })
+
+    expect(min).toBe('2026-Q3')
+    expect(max).toBe('2026-Q3')
   })
 
   test('获取当年范围', () => {
@@ -334,8 +342,8 @@ describe('getDateRange', () => {
     })
 
     const [min, max] = result
-    expect(min).toBe(baseDate.startOf('quarter').format('YYYY-[Q]Q'))
-    expect(max).toBe(baseDate.endOf('quarter').format('YYYY-[Q]Q'))
+    expect(min).toBe('2024-Q1')
+    expect(max).toBe('2024-Q1')
   })
 
   test('过去类型使用最小时间限制', () => {

--- a/tools/GetDateRange/__tests__/GetDateRange.test.ts
+++ b/tools/GetDateRange/__tests__/GetDateRange.test.ts
@@ -154,7 +154,7 @@ describe('getDateRange', () => {
   })
 
   test('传入不支持的类型时抛出错误', () => {
-    // @ts-expect-error: 强制传入非法类型以测试错误分支
+    // @ts-expect-error: force an invalid type to test the error branch
     expect(() => getDateRange({ type: 'invalid' })).toThrow('不支持的类型')
   })
 

--- a/tools/GetDateRange/index.ts
+++ b/tools/GetDateRange/index.ts
@@ -6,39 +6,39 @@ dayjs.extend(quarterOfYear)
 dayjs.extend(weekOfYear)
 
 export type DateRangeType =
-  | 'past' // 过去
-  | 'future' // 未来
-  | 'today' // 当日
-  | 'thisWeek' // 当周
-  | 'thisMonth' // 当月
-  | 'thisQuarter' // 当季
-  | 'thisYear' // 当年
+  | 'past' // past
+  | 'future' // future
+  | 'today' // today
+  | 'thisWeek' // this week
+  | 'thisMonth' // this month
+  | 'thisQuarter' // this quarter
+  | 'thisYear' // this year
 
 export interface GetDateRangeOptions {
-  /** 数量（用于过去/未来，表示天数、周数、月数等） */
+  /** Amount (for past/future; number of days, weeks, months, etc.) */
   amount?: number
-  /** 类型：过去、未来、当月、当日、当年、当季、当周等 */
+  /** Type: past, future, this month, today, this year, this quarter, this week, etc. */
   type: DateRangeType
-  /** 基准日期，默认为当前日期 */
+  /** Base date, defaults to the current date */
   baseDate?: string | Date | Dayjs
-  /** 单位（用于过去/未来），默认为 'day' */
+  /** Unit (for past/future), defaults to 'day' */
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'
-  /** 最小时间（用于过去/未来，限制范围不能小于此时间） */
+  /** Minimum date (for past/future; the range cannot go earlier than this) */
   minDate?: string | Date | Dayjs
-  /** 最大时间（用于过去/未来，限制范围不能大于此时间） */
+  /** Maximum date (for past/future; the range cannot go later than this) */
   maxDate?: string | Date | Dayjs
-  /** 是否包含时间部分，默认为 false */
+  /** Whether to include the time part, defaults to false */
   hasTime?: boolean
 }
 
-/** 时间段结果：[开始时间字符串, 结束时间字符串] */
+/** Date range result: [start time string, end time string] */
 export type DateRangeResult = [string, string]
 
-/** 根据类型 / 单位获取对应的格式 */
+/** Get the corresponding format string based on type / unit */
 function getFormat(type: DateRangeType, unit: GetDateRangeOptions['unit'] = 'day', hasTime: boolean = false): string {
   let baseFormat: string
 
-  // 固定类型优先
+  // Fixed types take precedence
   switch (type) {
     case 'today':
       baseFormat = 'YYYY-MM-DD'
@@ -58,7 +58,7 @@ function getFormat(type: DateRangeType, unit: GetDateRangeOptions['unit'] = 'day
     case 'past':
     case 'future':
     default:
-      // 过去 / 未来等根据单位来决定
+      // For past / future etc., the format is decided by the unit
       switch (unit) {
         case 'year':
           baseFormat = 'YYYY'
@@ -69,7 +69,7 @@ function getFormat(type: DateRangeType, unit: GetDateRangeOptions['unit'] = 'day
         case 'second':
         case 'minute':
         case 'hour':
-          // 时、分、秒单位直接返回完整的时间格式
+          // For hour, minute and second units, return the full datetime format directly
           return 'YYYY-MM-DD HH:mm:ss'
         case 'week':
         case 'day':
@@ -80,7 +80,7 @@ function getFormat(type: DateRangeType, unit: GetDateRangeOptions['unit'] = 'day
       break
   }
 
-  // 如果 hasTime 为 true 且格式包含日期部分，则添加时间
+  // If hasTime is true and the format contains a date part, append the time
   if (hasTime && baseFormat.endsWith('DD')) {
     return `${baseFormat} HH:mm:ss`
   }
@@ -89,9 +89,9 @@ function getFormat(type: DateRangeType, unit: GetDateRangeOptions['unit'] = 'day
 }
 
 /**
- * 获取日期范围
- * @param options 配置选项
- * @returns 时间段数组 [min, max]
+ * Get a date range
+ * @param options configuration options
+ * @returns date range array [min, max]
  */
 export default function getDateRange(options: GetDateRangeOptions): DateRangeResult {
   const {
@@ -110,17 +110,17 @@ export default function getDateRange(options: GetDateRangeOptions): DateRangeRes
 
   switch (type) {
     case 'past':
-      // 过去：从 base - amount 到 base
+      // Past: from base - amount to base
       maxDate = base.endOf(unit)
       minDate = base.subtract(amount, unit).startOf(unit)
-      // 如果设置了最小时间限制，确保 minDate 不小于限制
+      // If a minimum date limit is set, make sure minDate is not earlier than it
       if (minDateLimit) {
         const minLimit = dayjs(minDateLimit).startOf(unit)
         if (minLimit.isAfter(minDate)) {
           minDate = minLimit
         }
       }
-      // 如果设置了最大时间限制，确保 maxDate 不大于限制
+      // If a maximum date limit is set, make sure maxDate is not later than it
       if (maxDateLimit) {
         const maxLimit = dayjs(maxDateLimit).endOf(unit)
         if (maxLimit.isBefore(maxDate)) {
@@ -130,17 +130,17 @@ export default function getDateRange(options: GetDateRangeOptions): DateRangeRes
       break
 
     case 'future':
-      // 未来：从 base 到 base + amount
+      // Future: from base to base + amount
       minDate = base.startOf(unit)
       maxDate = base.add(amount, unit).endOf(unit)
-      // 如果设置了最小时间限制，确保 minDate 不小于限制
+      // If a minimum date limit is set, make sure minDate is not earlier than it
       if (minDateLimit) {
         const minLimit = dayjs(minDateLimit).startOf(unit)
         if (minLimit.isAfter(minDate)) {
           minDate = minLimit
         }
       }
-      // 如果设置了最大时间限制，确保 maxDate 不大于限制
+      // If a maximum date limit is set, make sure maxDate is not later than it
       if (maxDateLimit) {
         const maxLimit = dayjs(maxDateLimit).endOf(unit)
         if (maxLimit.isBefore(maxDate)) {
@@ -150,31 +150,31 @@ export default function getDateRange(options: GetDateRangeOptions): DateRangeRes
       break
 
     case 'today':
-      // 当日：当天的开始到结束
+      // Today: from the start to the end of the current day
       minDate = base.startOf('day')
       maxDate = base.endOf('day')
       break
 
     case 'thisWeek':
-      // 当周：本周的开始到结束
+      // This week: from the start to the end of the current week
       minDate = base.startOf('week')
       maxDate = base.endOf('week')
       break
 
     case 'thisMonth':
-      // 当月：本月的开始到结束
+      // This month: from the start to the end of the current month
       minDate = base.startOf('month')
       maxDate = base.endOf('month')
       break
 
     case 'thisQuarter':
-      // 当季：本季度的开始到结束
+      // This quarter: from the start to the end of the current quarter
       minDate = base.startOf('quarter')
       maxDate = base.endOf('quarter')
       break
 
     case 'thisYear':
-      // 当年：本年的开始到结束
+      // This year: from the start to the end of the current year
       minDate = base.startOf('year')
       maxDate = base.endOf('year')
       break

--- a/tools/GetDateRange/index.ts
+++ b/tools/GetDateRange/index.ts
@@ -1,9 +1,12 @@
 import dayjs, { Dayjs } from 'dayjs'
 import quarterOfYear from 'dayjs/plugin/quarterOfYear'
 import weekOfYear from 'dayjs/plugin/weekOfYear'
+// advancedFormat supplies the `Q` format token; without it `YYYY-[Q]Q` renders as `YYYY-QQ`
+import advancedFormat from 'dayjs/plugin/advancedFormat'
 
 dayjs.extend(quarterOfYear)
 dayjs.extend(weekOfYear)
+dayjs.extend(advancedFormat)
 
 export type DateRangeType =
   | 'past' // past

--- a/tools/GetStrSize/index.ts
+++ b/tools/GetStrSize/index.ts
@@ -7,6 +7,12 @@ interface Font {
   family?: string
 }
 
+/**
+ * Asynchronously measure the rendered size of a string (waits for the font to load before measuring, giving a more accurate result)
+ * @param str the string to measure
+ * @param font font configuration (style / weight / size / family)
+ * @returns width and height of the string (px, rounded to two decimal places)
+ */
 export async function get_string_size_async(str: string, font: Font = {}): Promise<{ width: number; height: number }> {
   const { style = 'normal', weight = 'normal', size = 10, family: fontFamily = 'sans-serif' } = font
 
@@ -27,6 +33,12 @@ export async function get_string_size_async(str: string, font: Font = {}): Promi
   return { width: +width.toFixed(2), height: +height.toFixed(2) }
 }
 
+/**
+ * Synchronously measure the rendered size of a string (does not wait for font loading; results may be off if a custom font is not ready yet)
+ * @param str the string to measure
+ * @param font font configuration (style / weight / size / family)
+ * @returns width and height of the string (px, rounded to two decimal places)
+ */
 export default function get_string_size(str: string, font: Font = {}): { width: number; height: number } {
   const { style = 'normal', weight = 'normal', size = 10, family: fontFamily = 'sans-serif' } = font
 

--- a/tools/GetTimeDifference/index.ts
+++ b/tools/GetTimeDifference/index.ts
@@ -6,10 +6,16 @@ interface TimeDifference {
   milliseconds: number
 }
 
+/**
+ * Calculate the time difference between two points in time
+ * @param start start time (a string parsable by new Date())
+ * @param end end time (a string parsable by new Date())
+ * @returns the difference in days / hours / minutes / seconds / milliseconds
+ */
 export default function getTimeDifference(start: string, end: string): TimeDifference {
-  const diff = new Date(end).valueOf() - new Date(start).valueOf() // 时间差（毫秒）
+  const diff = new Date(end).valueOf() - new Date(start).valueOf() // time difference (milliseconds)
 
-  // 计算各单位的差值
+  // Compute the difference for each unit
   const days = Math.floor(diff / (1000 * 60 * 60 * 24))
   const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
   const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))

--- a/tools/LoadFont/index.ts
+++ b/tools/LoadFont/index.ts
@@ -11,6 +11,12 @@ export interface LoadFontOptions {
   text?: string
 }
 
+/**
+ * Asynchronously load a font, ensuring it is available for subsequent canvas drawing / size measurement
+ * @param options.ctx canvas context used for warm-up; an internal off-screen canvas is used if omitted
+ * @param options.font font configuration (style / weight / size / family)
+ * @param options.text warm-up text
+ */
 export default async function loadFont(options: LoadFontOptions) {
   const { ctx, font = {}, text } = options
   const { style = 'normal', weight = 'normal', size = 10, family = 'sans-serif' } = font

--- a/tools/LoadImage/index.ts
+++ b/tools/LoadImage/index.ts
@@ -1,13 +1,20 @@
-// 图片阻塞请求缓存
+// Cache of in-flight image requests
 const imagePromiseCache: { [key: string]: Promise<HTMLImageElement> | undefined } = {}
 
-// 图片缓存
+// Cache of loaded images
 const imageCache: { [key: string]: HTMLImageElement } = {}
 
+/**
+ * Asynchronously load an image with caching
+ *
+ * Results for the same url are cached and reused on subsequent calls; in-flight requests are also merged to avoid duplicate concurrent requests.
+ * @param url image URL
+ * @returns the loaded HTMLImageElement (rejects on load failure, with no error value)
+ */
 export default async function loadImage(url: string) {
-  // 如果图片已经请求过了，则直接返回缓存
+  // If the image has already been loaded, return the cached one directly
   if (imageCache[url]) return imageCache[url]
-  // 如果图片正在请求中，则返回请求中的图片
+  // If the image is currently being requested, return the pending request
   if (imagePromiseCache[url]) return imagePromiseCache[url] as Promise<HTMLImageElement>
 
   const imagePromise = new Promise<HTMLImageElement>((resolve, reject) => {

--- a/tools/RenderPDF/index.ts
+++ b/tools/RenderPDF/index.ts
@@ -22,6 +22,12 @@ interface RenderPageOption {
 
 const PDFMap = new Map<string, Promise<PDFDocumentProxy>>()
 
+/**
+ * Preload a PDF document (documents with the same pdfUrl are cached and reused)
+ * @param pdfUrl PDF file URL
+ * @param workerSrc custom pdf.js worker URL; defaults to the built-in CDN
+ * @returns the pdf.js PDFDocumentProxy
+ */
 async function load(pdfUrl: string, workerSrc?: string) {
   if (workerSrc) {
     GlobalWorkerOptions.workerSrc = workerSrc
@@ -44,12 +50,21 @@ async function load(pdfUrl: string, workerSrc?: string) {
   return await pdf
 }
 
+/**
+ * Get the total number of pages in a PDF
+ * @param pdfUrl PDF file URL
+ * @param workerSrc custom pdf.js worker URL
+ */
 async function getNumPages(pdfUrl: string, workerSrc?: string) {
   const pdf = await load(pdfUrl, workerSrc)
 
   return pdf.numPages
 }
 
+/**
+ * Clear the rendered PDF pages inside the container
+ * @param containerId id of the container element
+ */
 function clear(containerId: string) {
   const container = document.getElementById(containerId)
 
@@ -60,6 +75,16 @@ function clear(containerId: string) {
   })
 }
 
+/**
+ * Render a PDF into the given container (clears existing pages in the container first, then renders each page as a canvas)
+ * @param options.pdfUrl PDF file URL
+ * @param options.containerId id of the container element
+ * @param options.startPageNum start page number, defaults to page 1
+ * @param options.endPageNum end page number, defaults to the last page
+ * @param options.pixelRatio rendering pixel ratio, defaults to 2
+ * @param options.scale scale factor, defaults to 1
+ * @param options.workerSrc custom pdf.js worker URL
+ */
 async function render({ pdfUrl, containerId, startPageNum, endPageNum, pixelRatio, scale, workerSrc }: RenderOption) {
   clear(containerId)
 

--- a/tools/Typeof/index.ts
+++ b/tools/Typeof/index.ts
@@ -4,6 +4,12 @@ type ObjectType = 'object' | 'array' | 'null' | 'date' | 'formdata' | 'set' | 'm
 
 type Type = BaseType | ObjectType
 
+/**
+ * Get the type of a value, or check it against an expected type
+ * @param value the value to inspect
+ * @param isType expected type; if provided, returns a boolean (whether value is of that type), otherwise returns the type string
+ * @returns the type string (e.g. 'array' / 'date'), or the comparison result against isType
+ */
 export default function Typeof<T>(value: T, isType?: Type): boolean | Type {
   const object_type: string = Object.prototype.toString.call(value)
   const reg = new RegExp(' (.+?)]')


### PR DESCRIPTION
## 内容

- **fix**: `getDateRange({type:'thisQuarter'})` 输出 `2026-QQ` 而非 `2026-Q3` —— dayjs 核心无 `Q` 格式 token，引入 `advancedFormat` 插件补齐；季度测试改为固定基准日的字面值断言（原测试同义反复，无法发现此 bug）
- **docs**: README 统一结构（徽章/安装/使用/API/贡献/License）、修正 thisWeek 示例（本库以周日为一周起点）、修正 RenderOption 表格错误默认值；全部工具函数补英文 JSDoc
- **chore**: package.json 完善 description / keywords / homepage；版本 0.0.55

## 验证

- 232 个单测全过（新增跨季度字面值断言）
- `yarn build` 通过，lib 产物实测 `thisQuarter → 2026-Q3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)