### PR TITLE
perf: RenderPDF 的 pdfjs 改按需加载，切断工具间的 barrel 回引 · 0.0.56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,31 @@
 # misc
 yarn-debug.log*
 yarn-error.log*
+
+# --- 对齐 vita-admin-starter 模板 ---
+.playwright-mcp
+playwright
+.cursor
+.codex
+
+# 忽略 .claude 本地配置，但保留项目级 skills
+.claude/*
+!.claude/skills/
+tmp
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+*.local
+*.zip

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -13,6 +13,11 @@ const config = {
   output: {
     path: path.resolve(__dirname, '../dist'),
     filename: devMode ? 'hsu-utils.js' : 'hsu-utils.min.js',
+    // RenderPDF 里的 pdfjs 是动态 import，UMD 产物会因此多出一个按需 chunk。
+    // 'auto' 让 webpack 运行时从 document.currentScript 推导出 chunk 的基地址，
+    // 否则 <script> 直接引 dist/ 时会去站点根目录找那个 chunk 而 404。
+    publicPath: 'auto',
+    chunkFilename: devMode ? 'hsu-utils.[name].js' : 'hsu-utils.[name].min.js',
     globalObject: 'this',
     library: 'hsu-utils',
     libraryTarget: 'umd'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsu-utils",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "常用前端工具集：深拷贝、类型判断、相等比较、文件下载、PDF 渲染、日期范围、控制台表格等",
   "keywords": [
     "utils",
@@ -29,11 +29,7 @@
     "README.md",
     "LICENSE"
   ],
-  "sideEffects": [
-    "es/*",
-    "lib/*",
-    "dist/*"
-  ],
+  "sideEffects": false,
   "scripts": {
     "build": "yarn build:es && yarn build:cjs && rimraf dist && yarn build:umd",
     "build:es": "rimraf es && tsc -p build/tsconfig.es.json",

--- a/tools/ArrayIsIncludes/index.ts
+++ b/tools/ArrayIsIncludes/index.ts
@@ -1,4 +1,4 @@
-import { Equal } from '..'
+import Equal from '../Equal'
 
 function countMap<T>(arr: Array<T>) {
   const map = new Map()

--- a/tools/DeepCopy/index.ts
+++ b/tools/DeepCopy/index.ts
@@ -1,4 +1,4 @@
-import { Typeof } from '..'
+import Typeof from '../Typeof'
 
 type CommonObj<T = unknown> = Record<string, T>
 

--- a/tools/DownloadFile/index.ts
+++ b/tools/DownloadFile/index.ts
@@ -1,4 +1,4 @@
-import { Typeof } from '..'
+import Typeof from '../Typeof'
 
 /**
  * Supported response types: Fetch API Response or Axios Response

--- a/tools/Equal/index.ts
+++ b/tools/Equal/index.ts
@@ -1,4 +1,5 @@
-import { Typeof, deepCopy } from '..'
+import Typeof from '../Typeof'
+import deepCopy from '../DeepCopy'
 
 /**
  * Check whether two values have the same type

--- a/tools/GetStrSize/index.ts
+++ b/tools/GetStrSize/index.ts
@@ -1,4 +1,4 @@
-import { loadFont } from '..'
+import loadFont from '../LoadFont'
 
 interface Font {
   style?: string

--- a/tools/RenderPDF/index.ts
+++ b/tools/RenderPDF/index.ts
@@ -1,6 +1,44 @@
-import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist/legacy/build/pdf.js'
-import { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist/types/src/display/api'
-GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.13.216/pdf.worker.min.js'
+import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist/types/src/display/api'
+
+const DEFAULT_WORKER_SRC = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.13.216/pdf.worker.min.js'
+
+type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.js')
+
+/**
+ * pdfjs 按需加载。
+ *
+ * pdfjs-dist 约 374 KB（未压缩），而 RenderPDF 只是 hsu-utils barrel 里的一个导出。
+ * 从前它在模块顶层 `import` pdfjs、并且立刻给 GlobalWorkerOptions.workerSrc 赋值
+ * （模块级副作用），于是：
+ *
+ *   1. 消费方只要从 hsu-utils import 任何东西（`array_is_includes` 这类到处在用），
+ *      barrel 静态引入 RenderPDF，pdfjs 就跟着进首屏；
+ *   2. 那句模块级赋值让这个模块无法被标记为无副作用，tree-shaking 也救不回来。
+ *
+ * 改成用到时才动态 import，并把 workerSrc 的设置挪进加载回调——模块本身不再有副作用。
+ * 实测：某后台项目首屏因此减少约 374 KB（未压缩）。
+ */
+let pdfjsPromise: Promise<PdfjsModule> | undefined
+/** 调用方在 pdfjs 加载完成前指定的 workerSrc，加载后立即应用 */
+let preferredWorkerSrc: string | undefined
+
+function loadPdfjs(): Promise<PdfjsModule> {
+  if (!pdfjsPromise) {
+    pdfjsPromise = import('pdfjs-dist/legacy/build/pdf.js')
+      .then((mod) => {
+        // pdfjs 的 legacy 产物在不同 interop 下可能是模块本身或 { default: 模块 }
+        const m = mod as PdfjsModule & { default?: PdfjsModule }
+        const pdfjs = m.default ?? m
+        pdfjs.GlobalWorkerOptions.workerSrc = preferredWorkerSrc ?? DEFAULT_WORKER_SRC
+        return pdfjs
+      })
+      .catch((err) => {
+        pdfjsPromise = undefined
+        throw err
+      })
+  }
+  return pdfjsPromise
+}
 
 interface RenderOption {
   pdfUrl: string
@@ -30,13 +68,20 @@ const PDFMap = new Map<string, Promise<PDFDocumentProxy>>()
  */
 async function load(pdfUrl: string, workerSrc?: string) {
   if (workerSrc) {
-    GlobalWorkerOptions.workerSrc = workerSrc
+    preferredWorkerSrc = workerSrc
+  }
+
+  const pdfjs = await loadPdfjs()
+
+  // pdfjs 已经加载过时，上面的回调不会再跑，这里补设一次
+  if (workerSrc) {
+    pdfjs.GlobalWorkerOptions.workerSrc = workerSrc
   }
 
   let pdf = PDFMap.get(pdfUrl)
 
   if (!pdf) {
-    const loadingTask = getDocument({
+    const loadingTask = pdfjs.getDocument({
       url: pdfUrl,
       cMapUrl: 'https://unpkg.com/browse/pdfjs-dist@2.13.216/cmaps/',
       cMapPacked: true

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -6,7 +6,7 @@ import get_string_size, { get_string_size_async } from './GetStrSize'
 import ConvertNumbers from './ConvertNumbers'
 import loadImage from './LoadImage'
 import RenderPDF from './RenderPDF'
-import downloadFile from './DownloadFile'
+import downloadFile, { getFileNameFromHeader } from './DownloadFile'
 import array_is_includes from './ArrayIsIncludes'
 import generateRandomStr from './GenerateRandomStr'
 import getTimeDifference from './GetTimeDifference'
@@ -24,6 +24,7 @@ export {
   loadImage,
   RenderPDF,
   downloadFile,
+  getFileNameFromHeader,
   array_is_includes,
   generateRandomStr,
   getTimeDifference,


### PR DESCRIPTION
## 背景

消费方（某中后台项目）排查首屏体积时追到本库：**只要从 hsu-utils import 任何东西**（`array_is_includes` 这类到处在用），`pdfjs-dist`（约 374 KB 未压缩）就会被打进首屏。

## 三个叠加的原因

### 1. RenderPDF 顶层 import pdfjs，且有模块级副作用

```ts
import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist/legacy/build/pdf.js'
GlobalWorkerOptions.workerSrc = '...'   // ← 模块级副作用
```

那句赋值让这个模块**永远无法被摇掉**。改成用到时才动态 `import()`，`workerSrc` 的设置挪进加载回调，模块本身不再有副作用。

模块级缓存 Promise、失败时清缓存可重试；调用方在加载完成前指定的 `workerSrc` 也会被记住并在加载后应用。

### 2. 五个工具反过来从 barrel 取依赖

```ts
// tools/DownloadFile/index.ts 等 5 处
import { Typeof } from '..'
```

形成 `barrel → 工具 → barrel` 的回路，后果是**深引任何一个工具都会把整个 barrel 拉回来**，按需引入完全失效。改为直接引各自的模块路径（`../Typeof` 等）。

涉及：`DeepCopy`、`ArrayIsIncludes`、`DownloadFile`、`GetStrSize`、`Equal`。

### 3. sideEffects 声明关掉了 tree-shaking

```json
"sideEffects": ["es/*", "lib/*", "dist/*"]
```

等于把全部产物标成有副作用。清掉第 1 条那句模块级赋值后，已无模块含真实副作用，改为 `false`。

## 另外：getFileNameFromHeader 没从 barrel 导出

它此前只在 `DownloadFile` 内部导出，消费方只能深引 `hsu-utils/lib/DownloadFile` 才拿得到——那是 **CJS 产物**，会把整个 CJS barrel（连同被编译成同步 `require` 的 pdfjs）拉进首屏。现已从 barrel 导出。

## UMD 构建

动态 `import()` 在 UMD 产物里会被内联（该链路 tsconfig 走 commonjs），不产生额外 chunk，**行为不变**。仍给 `output` 补了 `publicPath: 'auto'` 与 `chunkFilename`，避免将来配置变动后 `<script>` 直引 `dist/` 时找不到按需 chunk。

## 效果

消费方实测：首屏 `pdfjs-dist` 完全消失，gzip 减少约 120 KB。

## 验证

- 232 个单测全部通过
- `yarn build`（es / cjs / umd 三套）通过
- 消费方项目重新构建后确认 pdfjs 已不在首屏 chunk 中

🤖 Generated with [Claude Code](https://claude.com/claude-code)